### PR TITLE
Fix stacker news referral link

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
                                 <a class="chxxe ct7p9 c3dwx c4j2n ck8vv cpw7x cf1po c2evh cr8s1 cqckt c2660" href="#up">Welcome</a>
                             </li>
                             <li>
-                                <a class="chxxe ct7p9 c3dwx c4j2n ck8vv cpw7x cf1po c2evh cr8s1 cqckt c2660" target="_blank" href="https://stacker.news/r/mo/search?q=PROXNUT&what=posts" alt="News" title="News">News</a>
+                                <a class="chxxe ct7p9 c3dwx c4j2n ck8vv cpw7x cf1po c2evh cr8s1 cqckt c2660" target="_blank" href="https://stacker.news/search/r/mo?q=PROXNUT&what=posts" alt="News" title="News">News</a>
                             </li>
                             <li>
                                 <a class="chxxe ct7p9 c3dwx c4j2n ck8vv cpw7x cf1po c2evh cr8s1 cqckt c2660" target="_blank" href="https://BOLT.FUN/projects/proxnut" alt="News" title="News">Blog</a>
@@ -122,7 +122,7 @@
                         
                             <!-- Item -->
                             <div class="ctlpz chxxe ct7p9 cllfr c4j2n cxapu aos-init aos-animate" data-aos="zoom-out">
-                              <a target="_blank" href="https://stacker.news/r/mo/search?q=PROXNUT&what=posts" alt="STACKER.NEWS">
+                              <a target="_blank" href="https://stacker.news/search/r/mo?q=PROXNUT&what=posts" alt="STACKER.NEWS">
                                 <svg width="154" height="36" viewBox="0 0 154 36" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_345_255)"><g filter="url(#filter0_d_345_255)"><path d="M9.99965 22.3563L5.78066 16.1498L14.7118 10L9.20517 16.8583L13.6707 22.9514L2 29.6113L9.99965 22.3563Z" fill="#B4B7C9"/><path d="M16.29 17.085L17.8516 15.8097L11.4135 14.4494L24.5911 13.3441L19.4132 17.5385L18.016 31L16.29 17.085Z" fill="#B4B7C9"/><path d="M27.0969 21.5911L31.3159 20.3725L22.193 26.7773L29.9187 10.9352L38.3841 29.668L29.6996 17.0283L27.0969 21.5911Z" fill="#B4B7C9"/><path d="M39.7997 18.8138L42.6215 23.8583L50.128 20.1741L42.1284 27.3725L36.293 18.8138L43.2242 10.8219L48.5117 17.2551L43.1694 14.2794L39.7997 18.8138Z" fill="#B4B7C9"/><path d="M60.8692 12.7773L56.2393 19.8907L64.6225 30.7166L54.5681 22.2996L49.9108 28.2794L52.1299 12.4372L52.623 20.9393L60.8692 12.7773Z" fill="#B4B7C9"/><path d="M70.3851 19.4939L65.9469 24.0283L73.426 29.1012L60.9334 24.8502L66.714 20.004L62.1115 15.3563L73.2069 11.2186L66.44 16.0931L70.3851 19.4939Z" fill="#B4B7C9"/><path d="M76.9175 15.753L74.4793 28.8178L74.3149 10.8785L83.4926 16.9717L80.4242 20.8826L86.3692 29.8947L77.4929 20.5992L79.8763 17.4818L76.9175 15.753Z" fill="#B4B7C9"/><path d="M101.316 14.1943L106.823 20.9393L111.096 10.5385L108.877 26.7206L102.357 19.8907L97.4258 27.6559L101.316 14.1943Z" fill="#B4B7C9"/><path d="M120.442 19.4939L116.004 24.0283L123.483 29.1012L110.99 24.8502L116.771 20.004L112.168 15.3563L123.264 11.2186L116.497 16.0931L120.442 19.4939Z" fill="#B4B7C9"/><path d="M129.709 16.2348L134.75 22.583L141.983 10.8219L135.435 28.8745L129.928 20.2024L125.654 27.9393L122.093 14.6194L126.257 21.7611L129.709 16.2348Z" fill="#B4B7C9"/><path d="M146.498 22.3563L142.279 16.1498L151.211 10L145.704 16.8583L150.169 22.9514L138.499 29.6113L146.498 22.3563Z" fill="#B4B7C9"/></g></g><defs><filter id="filter0_d_345_255" x="-2" y="6" width="157.211" height="29" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB"><feFlood flood-opacity="0" result="BackgroundImageFix"/><feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/><feOffset/><feGaussianBlur stdDeviation="2"/><feComposite in2="hardAlpha" operator="out"/><feColorMatrix type="matrix" values="0 0 0 0 0.705882 0 0 0 0 0.717647 0 0 0 0 0.788235 0 0 0 1 0"/><feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_345_255"/><feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_345_255" result="shape"/></filter><clipPath id="clip0_345_255"><rect width="154" height="36" fill="white"/></clipPath></defs></svg>
                               </a>
                             </div>
@@ -599,7 +599,7 @@
                                 </a>
 
                                 <!-- 6th Box -->
-                                <a class="c63pb c9jk5 ciofo c2ycl c9kad cbpf7 cdrgc c740e cgsao" target="_blank" href="https://stacker.news/r/mo/search?q=PROXNUT&what=posts" x-show="[&#39;1&#39;, &#39;2&#39;, &#39;4&#39;].includes(category)">
+                                <a class="c63pb c9jk5 ciofo c2ycl c9kad cbpf7 cdrgc c740e cgsao" target="_blank" href="https://stacker.news/search/r/mo?q=PROXNUT&what=posts" x-show="[&#39;1&#39;, &#39;2&#39;, &#39;4&#39;].includes(category)">
                                     <div class="c63pb cdkg1 chxxe crj8b cz55x ct7p9 cllfr cc33u cwnot chhhh ccgb9 c1jst c2ycl c9kad cbpf7 cy9g1 czdo8 cm598 c1xav ct5he ctea0 c740e">
                                         <svg class="cej5m cf1po c2evh cr8s1 cuypv" width="22" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 22 22" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                                             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
@@ -716,7 +716,7 @@
                                 <a class="cpw7x cf1po c2evh cr8s1 cqckt" href="#up">Features</a>
                             </li>
                             <li>
-                                <a class="cpw7x cf1po c2evh cr8s1 cqckt" target="_blank" href="https://stacker.news/r/mo/search?q=PROXNUT&what=posts">News</a>
+                                <a class="cpw7x cf1po c2evh cr8s1 cqckt" target="_blank" href="https://stacker.news/search/r/mo?q=PROXNUT&what=posts">News</a>
                             </li>
                             <li>
                                 <a class="cpw7x cf1po c2evh cr8s1 cqckt" target="_blank" href="https://BOLT.FUN/project/proxnut">Blog</a>


### PR DESCRIPTION
Replaces

> https://stacker.news/r/mo/search?q=PROXNUT&what=posts

with

> https://stacker.news/search/r/mo?q=PROXNUT&what=posts

Closes https://github.com/gandlafbtc/proxnut/issues/3